### PR TITLE
fix: Plugin is not working with IDA 7.3

### DIFF
--- a/referee.py
+++ b/referee.py
@@ -145,12 +145,14 @@ def add_struct_xrefs(cfunc):
                 # to get the structure/member associated with its use
                 typ = e.x.type
 
-                if e.op == idaapi.cot_memptr:
-                    typ.remove_ptr_or_array()
+                if e.op == idaapi.cot_memptr and typ.is_ptr_or_array():
+                    typ = typ.get_ptrarr_object();
 
                 strname = typ.dstr()
                 if strname.startswith("struct "):
                     strname = strname[len("struct "):]
+                if strname.startswith("union "):
+                    strname = strname[len("union "):]
 
                 stid = idaapi.get_struc_id(strname)
                 struc = idaapi.get_struc(stid)
@@ -170,6 +172,9 @@ def add_struct_xrefs(cfunc):
                 strname = e.type.dstr()
                 if strname.startswith("struct "):
                     strname = strname[len("struct "):]
+                if strname.startswith("union "):
+                    strname = strname[len("union "):]
+
 
                 stid = idaapi.get_struc_id(strname)
                 struc = idaapi.get_struc(stid)


### PR DESCRIPTION
`remove_ptr_or_array` somehow breaks entire hex rays decompiler in the 7.3 version, this simple fix makes it work again. I'm not 100% sure that union stuff is needed for fix to work, but it seems to be related: https://github.com/joeleong/ida-referee/issues/2